### PR TITLE
todo_tableにenumを追加

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Plan < ApplicationRecord
-  enum executed_status: { unfinished: 0, finished: 1}
   belongs_to :user
   has_many :todo_plans, dependent: :destroy
   has_many :todos, through: :todo_plans

--- a/db/fixtures/20_todos.rb
+++ b/db/fixtures/20_todos.rb
@@ -7,6 +7,7 @@ Todo.seed do |s|
   s.url = "http://www.isejingu.or.jp/"
   s.caution = "白い蛇が出ます"
   s.eager_status = 2
+  s.executed_status = 1
   s.user_id = User.find_by(name: "浦飯幽助").id
 end
 
@@ -17,6 +18,7 @@ Todo.seed do |s|
   s.url = "http://www.sakurajima.gr.jp/"
   s.caution = "噴火に注意"
   s.eager_status = 4
+  s.executed_status = 0
   s.user_id = User.find_by(name: "浦飯幽助").id
 end
 
@@ -27,5 +29,6 @@ Todo.seed do |s|
   s.url = "https://magia.tokyo/"
   s.caution = nil
   s.eager_status = 5
+  s.executed_status = 0
   s.user_id = User.find_by(name: "コエンマ").id
 end

--- a/db/migrate/20180610103048_create_todos.rb
+++ b/db/migrate/20180610103048_create_todos.rb
@@ -8,6 +8,7 @@ class CreateTodos < ActiveRecord::Migration[5.2]
       t.text        :url
       t.string      :caution
       t.integer     :eager_status, null: false, default: 0, limit: 1
+      t.integer    :executed_status, null: false, default: 0, limit: 1
       t.references  :user, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2018_06_10_110042) do
     t.text "url"
     t.string "caution"
     t.integer "eager_status", limit: 1, default: 0, null: false
+    t.integer "executed_status", limit: 1, default: 0, null: false
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
#やったこと
- todo_tableにexecuted_statusカラムを追加
- planモデルからexecuted_statusの翻訳メソッドを削除